### PR TITLE
protocol tweaks

### DIFF
--- a/src/buoy_protocol.erl
+++ b/src/buoy_protocol.erl
@@ -55,7 +55,7 @@ request(Method, Path, Headers, Host, Body) ->
         <<"\r\nConnection: Keep-alive\r\n">>,
         <<"User-Agent: buoy\r\n">>,
         format_headers(Headers2), <<"\r\n">>,
-        Body, <<"\r\n">>].
+        Body].
 
 -spec response(binary()) ->
     {ok, buoy_resp(), binary()} | error().
@@ -134,7 +134,9 @@ content_length([_ | T]) ->
 format_method(get) ->
     <<"GET">>;
 format_method(post) ->
-    <<"POST">>.
+    <<"POST">>;
+format_method(put) ->
+    <<"PUT">>.
 
 format_headers(Headers) ->
     [format_header(Header) || Header <- Headers].

--- a/test/buoy_protocol_tests.erl
+++ b/test/buoy_protocol_tests.erl
@@ -28,8 +28,15 @@ request_test() ->
         <<"127.0.0.1:8080">>, <<"Hello World!">>),
     ?assertEqual(<<"POST / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\n",
         "Connection: Keep-alive\r\nUser-Agent: buoy\r\n",
-        "Content-Length: 12\r\n\r\nHello World!\r\n">>,
-        iolist_to_binary(Request2)).
+        "Content-Length: 12\r\n\r\nHello World!">>,
+        iolist_to_binary(Request2)),
+
+    Request3 = buoy_protocol:request(put, <<"/">>, [],
+        <<"127.0.0.1:8080">>, <<"Hello World!">>),
+    ?assertEqual(<<"PUT / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\n",
+        "Connection: Keep-alive\r\nUser-Agent: buoy\r\n",
+        "Content-Length: 12\r\n\r\nHello World!">>,
+        iolist_to_binary(Request3)).
 
 response_test_() -> [
         fun response_200_subtest/0,


### PR DESCRIPTION
- allow PUT as an HTTP verb
- as per RFC2616, trailing CRLF is disallowed.

Some fixing issues I ran into running against a custom, elli-based server at work.